### PR TITLE
Update Readme.md - Add Planning section

### DIFF
--- a/snap-protect/storage-scale/Readme.md
+++ b/snap-protect/storage-scale/Readme.md
@@ -37,7 +37,7 @@ This project is under [Apache License 2.0](../../LICENSE).
 
 ------------------------------
 
-## Prerequisites
+## Planning
 
 This section describes the configuration model of the Storage Scale file systems and filesets used by the Storage Protect instance.
 


### PR DESCRIPTION
Rename Prerequisites section as Planning as it's more inline with the official product documentation for IBM Storage Protect, and actually is providing information about the initial configuration required before using the Scale SGC functionality to safeguard IBM Storage Protect deployment on Storage Scale.